### PR TITLE
resin-udevmount: add LIC_FILES_CHKSUM for ISC

### DIFF
--- a/layers/meta-resin-chip/recipes-support/resin-udevmount/resin-udevmount.bb
+++ b/layers/meta-resin-chip/recipes-support/resin-udevmount/resin-udevmount.bb
@@ -1,5 +1,6 @@
 SUMMARY = "udev rules for UBIFS"
 LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/ISC;md5=f3b90e78ea0cffb20bf5cca7947a896d"
 
 SRC_URI = "file://ubifs.rules"
 


### PR DESCRIPTION
This fixes a QA issue