### PR TITLE
resin-udevmount: relicense from ISC to MIT

### DIFF
--- a/layers/meta-resin-chip/recipes-support/resin-udevmount/resin-udevmount.bb
+++ b/layers/meta-resin-chip/recipes-support/resin-udevmount/resin-udevmount.bb
@@ -1,6 +1,6 @@
 SUMMARY = "udev rules for UBIFS"
-LICENSE = "ISC"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/ISC;md5=f3b90e78ea0cffb20bf5cca7947a896d"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = "file://ubifs.rules"
 


### PR DESCRIPTION
We don't use ISC anywhere else.