### PR TITLE
resin-udevmount: relicense from MIT to Apache-2.0

### DIFF
--- a/layers/meta-resin-chip/recipes-support/resin-udevmount/resin-udevmount.bb
+++ b/layers/meta-resin-chip/recipes-support/resin-udevmount/resin-udevmount.bb
@@ -1,6 +1,6 @@
 SUMMARY = "udev rules for UBIFS"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = "file://ubifs.rules"
 


### PR DESCRIPTION
This is our preferred licence.