### PR TITLE
packagegroup-resin-connectivity: install rtl8723bs firmware and drivers

### DIFF
--- a/layers/meta-resin-chip/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/layers/meta-resin-chip/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -1,0 +1,1 @@
+CONNECTIVITY_PACKAGES_append = " kernel-module-r8723bs rtl8723bs"


### PR DESCRIPTION
This adds support for the builtin wifi device.