### PR TITLE
Switch from aufs to overlayfs for the docker storage driver

### DIFF
--- a/layers/meta-resin-chip/conf/samples/local.conf.sample
+++ b/layers/meta-resin-chip/conf/samples/local.conf.sample
@@ -1,6 +1,9 @@
 # Supported machines
 #MACHINE ?= "chip"
 
+# We use the overlayfs docker storage driver on the CHIP
+DOCKER_STORAGE = "overlay2"
+
 # More info meta-resin/README.md
 #RESIN_CONNECTABLE ?= "1"
 #RESIN_CONNECTABLE_ENABLE_SERVICES ?= "0"


### PR DESCRIPTION
* overlay2 doesn't work yet, see FD discussion
* This PR depends on a newer meta-resin version

So don't merge yet.