### PR TITLE
packagegroup-resin: remove resin-filesystem-expand

### DIFF
--- a/layers/meta-resin-chip/recipes-core/packagegroups/packagegroup-resin.bbappend
+++ b/layers/meta-resin-chip/recipes-core/packagegroups/packagegroup-resin.bbappend
@@ -1,1 +1,3 @@
 RDEPENDS_${PN} += " resin-udevmount"
+
+RDEPENDS_${PN}_remove = "resin-filesystem-expand"


### PR DESCRIPTION
To resize a ubi filesystem for the data partition we need to pass
vol_flags=autoresize to ubinize. This will make the partition use all
remaining space. The resin-filesystem-expand service is unneeded for ubi.